### PR TITLE
Use IdenticalLink instead of EqualLink

### DIFF
--- a/opencog/pln/rules/extensional/concept-direct-evaluation.scm
+++ b/opencog/pln/rules/extensional/concept-direct-evaluation.scm
@@ -32,7 +32,7 @@
         (Evaluation
           (GroundedPredicate "scm: absolutely-true")
           (Member Y A))
-        (Not (Equal X Y)))
+        (Not (Identical X Y)))
       (ExecutionOutput
         (GroundedSchema "scm: concept-direct-evaluation")
         (List

--- a/opencog/pln/rules/intensional/intensional-difference-direct-introduction.scm
+++ b/opencog/pln/rules/intensional/intensional-difference-direct-introduction.scm
@@ -88,7 +88,7 @@
             (Attraction A X)
             (Attraction B X)))
         ;; A and B are different
-        (Not (Equal A B)))
+        (Not (Identical A B)))
       (ExecutionOutput
         (GroundedSchema "scm: intensional-difference-direct-introduction")
         (List

--- a/opencog/pln/rules/intensional/intensional-inheritance-direct-introduction.scm
+++ b/opencog/pln/rules/intensional/intensional-inheritance-direct-introduction.scm
@@ -92,7 +92,7 @@
             (Attraction A X)
             (Attraction B X)))
         ;; A and B are different
-        (Not (Equal A B)))
+        (Not (Identical A B)))
       (ExecutionOutput
         (GroundedSchema "scm: intensional-inheritance-direct-introduction")
         (List

--- a/opencog/pln/rules/intensional/intensional-similarity-direct-introduction.scm
+++ b/opencog/pln/rules/intensional/intensional-similarity-direct-introduction.scm
@@ -88,7 +88,7 @@
             (Attraction A X)
             (Attraction B X)))
         ;; A and B are different
-        (Not (Equal A B)))
+        (Not (Identical A B)))
       (ExecutionOutput
         (GroundedSchema "scm: intensional-similarity-direct-introduction")
         (List

--- a/opencog/pln/rules/temporal/predictive-implication-scope-direct-introduction.scm
+++ b/opencog/pln/rules/temporal/predictive-implication-scope-direct-introduction.scm
@@ -80,7 +80,7 @@
       (TypedVariable Q EvalT))
     (And
       (Present P1 P2 A Q)
-      (Not (Equal P1 P2))
+      (Not (Identical P1 P2))
       ;; TODO: add Satisfaction to fulfill the existential condition
       )
     (ExecutionOutput

--- a/opencog/pln/rules/wip/abduction.scm
+++ b/opencog/pln/rules/wip/abduction.scm
@@ -37,7 +37,7 @@
                 (VariableNode "$C")
                 (VariableNode "$B"))
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$A")
                     (VariableNode "$C"))))
         (ExecutionOutputLink

--- a/opencog/pln/rules/wip/and-as-1st-arg-inside-inheritance-link.scm
+++ b/opencog/pln/rules/wip/and-as-1st-arg-inside-inheritance-link.scm
@@ -31,7 +31,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C"))
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$A")
                     (VariableNode "$B"))))
         (ExecutionOutputLink

--- a/opencog/pln/rules/wip/and-as-2nd-arg-inside-inheritance-link.scm
+++ b/opencog/pln/rules/wip/and-as-2nd-arg-inside-inheritance-link.scm
@@ -31,7 +31,7 @@
                 (VariableNode "$A")
                 (VariableNode "$C"))
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$A")
                     (VariableNode "$B"))))
         (ExecutionOutputLink

--- a/opencog/pln/rules/wip/and-introduction.scm
+++ b/opencog/pln/rules/wip/and-introduction.scm
@@ -40,7 +40,7 @@
         (VariableNode "$A")
         (VariableNode "$B")
         (NotLink
-           (EqualLink
+           (IdenticalLink
               (VariableNode "$A")
               (VariableNode "$B"))))
      (ExecutionOutputLink
@@ -98,15 +98,15 @@
         ;; Weird this doesn't work at all. Instead we put this in
         ;; condition in the formula.
         (NotLink
-           (EqualLink
+           (IdenticalLink
               (VariableNode "$A")
               (VariableNode "$B")))
         (NotLink
-           (EqualLink
+           (IdenticalLink
               (VariableNode "$B")
               (VariableNode "$C")))
         (NotLink
-           (EqualLink
+           (IdenticalLink
               (VariableNode "$C")
               (VariableNode "$A")))
         (EvaluationLink

--- a/opencog/pln/rules/wip/implication-direct-evaluation.scm
+++ b/opencog/pln/rules/wip/implication-direct-evaluation.scm
@@ -66,7 +66,7 @@
         (Variable "$Q")
         (Variable "$X"))
      (Not
-        (Equal
+        (Identical
            (Variable "$P")
            (Variable "$Q")))))
 

--- a/opencog/pln/rules/wip/implication-implicant-conjunction.scm
+++ b/opencog/pln/rules/wip/implication-implicant-conjunction.scm
@@ -43,7 +43,7 @@
      (ImplicationLink
         (VariableNode "$B")
         (VariableNode "$C"))
-     (NotLink (EqualLink (VariableNode "$A") (VariableNode "$B")))))
+     (NotLink (IdenticalLink (VariableNode "$A") (VariableNode "$B")))))
 
 (define implication-implicant-conjunction-rewrite
   (ExecutionOutput

--- a/opencog/pln/rules/wip/implication-introduction.scm
+++ b/opencog/pln/rules/wip/implication-introduction.scm
@@ -40,7 +40,7 @@
            (VariableNode "$P")
            (VariableNode "$Q")))
      (NotLink
-        (EqualLink
+        (IdenticalLink
            (VariableNode "$P")
            (VariableNode "$Q")))))
 

--- a/opencog/pln/rules/wip/induction.scm
+++ b/opencog/pln/rules/wip/induction.scm
@@ -36,7 +36,7 @@
                 (VariableNode "$A")
                 (VariableNode "$C"))
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$B")
                     (VariableNode "$C"))))
         (ExecutionOutputLink
@@ -66,7 +66,7 @@
                 (VariableNode "$A")
                 (VariableNode "$C"))
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$B")
                     (VariableNode "$C"))))
         (ExecutionOutputLink
@@ -96,7 +96,7 @@
                 (VariableNode "$A")
                 (VariableNode "$C"))
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$B")
                     (VariableNode "$C"))))
         (ExecutionOutputLink

--- a/opencog/pln/rules/wip/or-introduction.scm
+++ b/opencog/pln/rules/wip/or-introduction.scm
@@ -35,7 +35,7 @@
         (VariableNode "$A")
         (VariableNode "$B")
         (NotLink
-           (EqualLink
+           (IdenticalLink
               (VariableNode "$A")
               (VariableNode "$B"))))
      (ExecutionOutputLink

--- a/opencog/pln/rules/wip/temp-deduction.scm
+++ b/opencog/pln/rules/wip/temp-deduction.scm
@@ -14,7 +14,7 @@
                 (VariableNode "$B")
                 (VariableNode "$C"))
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$A")
                     (VariableNode "$C")
                 )))


### PR DESCRIPTION
The pattern engine can do optimizations with `IdenticalLink` that are not possible with `EqualLink` although I admit, for the not-equal/not-identical case, it probably doesn't matter.